### PR TITLE
Create initial team charter

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,44 @@
+# Team charter
+
+The team charter is dynamic following the conda governance policy, with the following caveats:
+
+- 🧰 The team’s purpose is to develop and maintain code included in the conda/installer repository. That repository contains among other things tools and scripts to make it incredible easy to create and maintain installers similar to the current “miniconda” or “miniforge” installers.
+
+- 📨 The team acknowledges the need for better coordination between stakeholders that work on installers and bootstrappers in the conda community.
+
+- 📢 To enable accountability and predictability towards end users, the team commits to open and transparent communication about the release process, whenever possible.
+
+- ♻️ The team will abstract code shared between the various installers in the ecosystem in a central location to reduce diverging implementations.
+
+## Members
+
+### conda & constructor maintainers
+
+- @jezdez
+- @chenghlee
+- @jaimergp
+
+### miniforge maintainers
+
+- @xhochy
+- @hmaarfk
+- @isuruf (also constructor maintainer)
+
+### Anaconda packaging
+- @AndrewVallette
+- @marcoesters
+- @psteyer
+- @pseudoyim (also constructor maintainer)
+
+### Anaconda infra
+
+- @dbast
+
+### Anaconda security
+
+- @awwad
+- @pkmooreanaconda
+
+### Anaconda custom services
+
+- @jlstevens


### PR DESCRIPTION
This is the first version of the team charter and the _starting point_ of the conversation.

If and when the installer project is asking the conda steering council to vote on the graduation to the main conda organization, this will come in handy.

@xhochy, @hmaarfk, @isuruf, @awwad and @pkmooreanaconda I've added you to the list below without having had a chance to talk to you in detail about this. I would appreciate if you could let me know **if you're interested in participating in this new community team**?
