### PR TITLE
Create composite action to create constructor-based installers

### DIFF
--- a/.github/workflows/test-container.yaml
+++ b/.github/workflows/test-container.yaml
@@ -1,0 +1,119 @@
+name: Test container
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-installer:
+    name: Container builds (${{ matrix.artifact-suffix }})
+    runs-on: ubuntu-latest
+    env:
+      MICROMAMBA_VERSION: 2.0.8
+      MICROMAMBA_BUILD: 0
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - container-image: continuumio/miniconda3
+            container-architecture: linux/aarch64
+            artifact-suffix: miniconda-aarch64
+          - container-image: continuumio/miniconda3
+            artifact-suffix: miniconda-x86_64
+          - container-image: condaforge/linux-anvil-aarch64
+            container-architecture: linux/aarch64
+            target-platform: linux-aarch64
+            artifact-suffix: miniforge-aarch64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+
+      - name: Download micromamba
+        id: download-micromamba
+        if: startswith(matrix.container-image, 'condaforge/')
+        env:
+          TARGET_PLATFORM: ${{ matrix.target-platform }}
+        run: |
+          # Use a custom script since setup-micromamba does not support
+          # cross-platform downloads.
+          MICROMAMBA_DIR="${{ runner.temp }}/micromamba"
+          MICROMAMBA_BIN="${MICROMAMBA_DIR}/micromamba"
+          VERSION="${MICROMAMBA_VERSION}-${MICROMAMBA_BUILD}"
+          MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${VERSION}/micromamba-${TARGET_PLATFORM}"
+          mkdir -p "${MICROMAMBA_DIR}"
+          curl -L -o "${MICROMAMBA_BIN}" "${MICROMAMBA_URL}"
+          chmod 755 "${MICROMAMBA_BIN}"
+          echo "micromamba-path=${MICROMAMBA_BIN}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Create installer
+        id: create-installer
+        uses: ./
+        with:
+          environment-yaml-string: |
+            channels:
+              - ${{ startswith(matrix.container-image, 'condaforge/') && 'conda-forge' || 'defaults' }}
+            dependencies:
+              - constructor
+            variables:
+              ${{ startswith(matrix.container-image, 'condaforge/') && 'CONDA_OVERRIDE_GLIBC: 2.17' || '' }}
+          container-arch: ${{ matrix.container-architecture }}
+          container-image: ${{ matrix.container-image }}
+          standalone-location: ${{ steps.download-micromamba.outputs.micromamba-path }}
+          recipe-directory: ${{ startswith(matrix.container-image, 'condaforge/') && 'recipes/micromamba' || 'recipes/defaults' }}
+
+      - name: Upload installer to Github artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2
+        with:
+          path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
+          name: container-test-${{ matrix.artifact-suffix }}
+          retention-days: 5
+
+      - name: Determine installer file name
+        id: installer-file
+        run: |
+          INSTALLER_FILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.sh" | head -n 1)
+          echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Verify hashes
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+          INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
+        run: |
+          cd ${ARTIFACTS_DIRECTORY}
+          sha256sum -c "${INSTALLER_FILE}.sha256"
+        shell: bash
+
+      - name: Create test container
+        id: test-container
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+        run: |
+          docker run -d --rm -ti --name installer-test\
+            -v "${ARTIFACTS_DIRECTORY}:${ARTIFACTS_DIRECTORY}"\
+            -v "${{ runner.temp }}":"${{ runner.temp }}"\
+            ${{ startswith(matrix.container-image, 'condaforge') && '-e MICROMAMBA_VERSION' || '' }}\
+            ${{ matrix.container-architecture && format('--platform {0}', matrix.container-architecture) || '' }}\
+            debian:latest
+            /bin/bash
+        shell: bash
+
+      - name: Test installer
+        run: |
+          export INSTALL_DIR="${HOME}/testinstall"
+          INSTALLER_FILE="${{ steps.installer-file.outputs.installer-file }}"
+          bash "${INSTALLER_FILE}" -b -p "${INSTALL_DIR}"
+          . ${INSTALL_DIR}/etc/profile.d/conda.sh
+          conda activate
+          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')) == Path(info['root_prefix'])"
+          ${{ startswith(matrix.container-image, 'condaforge') && 'test "$(${INSTALL_DIR}/_conda --version)" == "${MICROMAMBA_VERSION}"' || '' }}
+        shell: docker exec -i installer-test /bin/bash -eo pipefail {0}

--- a/.github/workflows/test-container.yaml
+++ b/.github/workflows/test-container.yaml
@@ -71,7 +71,7 @@ jobs:
           container-arch: ${{ matrix.container-architecture }}
           container-image: ${{ matrix.container-image }}
           standalone-location: ${{ steps.download-micromamba.outputs.micromamba-path }}
-          recipe-directory: ${{ startswith(matrix.container-image, 'condaforge/') && 'recipes/micromamba' || 'recipes/defaults' }}
+          input-directory: ${{ startswith(matrix.container-image, 'condaforge/') && 'recipes/micromamba' || 'recipes/defaults' }}
 
       - name: Upload installer to Github artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2

--- a/.github/workflows/test-container.yaml
+++ b/.github/workflows/test-container.yaml
@@ -1,11 +1,10 @@
-name: Test container
+name: Test container builds
 
 on:
   pull_request:
   push:
     branches:
       - main
-      - tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/test-container.yaml
+++ b/.github/workflows/test-container.yaml
@@ -2,6 +2,10 @@ name: Test container builds
 
 on:
   pull_request:
+    paths:
+      - action.yaml
+      - recipes/**
+      - .github/workflows/test-container.yaml
   push:
     branches:
       - main

--- a/.github/workflows/test-container.yaml
+++ b/.github/workflows/test-container.yaml
@@ -86,8 +86,10 @@ jobs:
 
       - name: Determine installer file name
         id: installer-file
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
         run: |
-          INSTALLER_FILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.sh" | head -n 1)
+          INSTALLER_FILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.sh" | head -n 1)
           echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
         shell: bash
 
@@ -104,20 +106,20 @@ jobs:
         id: test-container
         env:
           ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+          INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
         run: |
           docker run -d --rm -ti --name installer-test\
             -v "${ARTIFACTS_DIRECTORY}:${ARTIFACTS_DIRECTORY}"\
-            -v "${{ runner.temp }}":"${{ runner.temp }}"\
-            ${{ startswith(matrix.container-image, 'condaforge') && '-e MICROMAMBA_VERSION' || '' }}\
+            -v "${RUNNER_TEMP}":"${RUNNER_TEMP}"\
             ${{ matrix.container-architecture && format('--platform {0}', matrix.container-architecture) || '' }}\
+            ${{ startswith(matrix.container-image, 'condaforge') && '-e MICROMAMBA_VERSION' || '' }}\
+            -e INSTALLER_FILE\
             debian:latest
-            /bin/bash
         shell: bash
 
       - name: Test installer
         run: |
           export INSTALL_DIR="${HOME}/testinstall"
-          INSTALLER_FILE="${{ steps.installer-file.outputs.installer-file }}"
           bash "${INSTALLER_FILE}" -b -p "${INSTALL_DIR}"
           . ${INSTALL_DIR}/etc/profile.d/conda.sh
           conda activate

--- a/.github/workflows/test-container.yaml
+++ b/.github/workflows/test-container.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Download micromamba
         id: download-micromamba

--- a/.github/workflows/test-defaults.yaml
+++ b/.github/workflows/test-defaults.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -25,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830  # v3.1.1

--- a/.github/workflows/test-defaults.yaml
+++ b/.github/workflows/test-defaults.yaml
@@ -91,7 +91,7 @@ jobs:
           fi
           . ${CONDA}/etc/profile.d/conda.sh
           conda activate
-          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')) == Path(info['root_prefix'])"
+          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')).samefile(info['root_prefix'])"
           if [[ $(uname) == MINGW* ]]; then
               test -f "${CONDA}/install.log"
           fi

--- a/.github/workflows/test-defaults.yaml
+++ b/.github/workflows/test-defaults.yaml
@@ -2,6 +2,10 @@ name: Test defaults
 
 on:
   pull_request:
+    paths:
+      - action.yaml
+      - recipes/defaults/construct.yaml
+      - .github/workflows/test-defaults.yaml
   push:
     branches:
       - main

--- a/.github/workflows/test-defaults.yaml
+++ b/.github/workflows/test-defaults.yaml
@@ -62,8 +62,10 @@ jobs:
 
       - name: Determine installer file name
         id: installer-file
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
         run: |
-          SHAFILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.sha256" | head -n 1)
+          SHAFILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.sha256" | head -n 1)
           echo "installer-file=${SHAFILE/\.sha256/}" >> ${GITHUB_OUTPUT}
         shell: bash
 

--- a/.github/workflows/test-defaults.yaml
+++ b/.github/workflows/test-defaults.yaml
@@ -1,0 +1,94 @@
+name: Test defaults
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-installer:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+    name: Miniconda, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830  # v3.1.1
+        with:
+          activate-environment: ''
+          run-post: false
+
+      - name: Create installer
+        id: create-installer
+        uses: ./
+        with:
+          environment-yaml-string: |
+            channels:
+              - defaults
+            dependencies:
+              - constructor
+              ${{ matrix.os == 'windows' && '- nsis=*=*_log_*' || '' }}
+            variables:
+              ${{ matrix.os == 'macos' && 'CONDA_OVERRIDE_OSX: 12.0' || '' }}
+              EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
+              NSIS_USING_LOG_BUILD: 1
+          conda-root: ${{ env.CONDA }}
+          recipe-directory: recipes/defaults
+
+      - name: Upload installer to Github artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2
+        with:
+          path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
+          name: defaults-test-${{ matrix.os }}
+          retention-days: 5
+
+      - name: Determine installer file name
+        id: installer-file
+        run: |
+          SHAFILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.sha256" | head -n 1)
+          echo "installer-file=${SHAFILE/\.sha256/}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Verify hashes
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+          INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
+        run: |
+          UNAME=$(uname)
+          [[ "${UNAME}" == MINGW* ]] && ARTIFACTS_DIRECTORY=$(cygpath "${ARTIFACTS_DIRECTORY}")
+          [[ "${UNAME}" == "Darwin" ]] && SHACMD="shasum -a 256" || SHACMD=sha256sum
+          cd ${ARTIFACTS_DIRECTORY}
+          ${SHACMD} -c "${INSTALLER_FILE}.sha256"
+        shell: bash
+
+      - name: Run installer
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830       # v3.1.1
+        with:
+          activate-environment: ''
+          installation-dir: ${{ runner.temp }}/installer_test
+          installer-url: file://${{ steps.installer-file.outputs.installer-file }}
+
+      - name: Test installer
+        env:
+          INSTALL_DIR: ${{ runner.temp }}/installer_test
+        run: |
+          if [[ $(uname) == MINGW* ]]; then
+              CONDA=$(cygpath "${CONDA}")
+          fi
+          . ${CONDA}/etc/profile.d/conda.sh
+          conda activate
+          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')) == Path(info['root_prefix'])"
+          if [[ $(uname) == MINGW* ]]; then
+              test -f "${CONDA}/install.log"
+          fi
+        shell: bash

--- a/.github/workflows/test-defaults.yaml
+++ b/.github/workflows/test-defaults.yaml
@@ -47,7 +47,7 @@ jobs:
               EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
               NSIS_USING_LOG_BUILD: 1
           conda-root: ${{ env.CONDA }}
-          recipe-directory: recipes/defaults
+          input-directory: recipes/defaults
 
       - name: Upload installer to Github artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2

--- a/.github/workflows/test-failure.yaml
+++ b/.github/workflows/test-failure.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: ./
         id: run-action
         with:
-          recipe-directory: recipes/defaults
+          input-directory: recipes/defaults
         continue-on-error: true
 
       - name: Error if successful
@@ -47,7 +47,7 @@ jobs:
         with:
           container-image: debian:latest  # Does not contain conda or mamba
           environment-yaml-file: recipes/defaults/environment.yaml
-          recipe-directory: recipes/defaults
+          input-directory: recipes/defaults
         continue-on-error: true
 
       - name: Error if successful

--- a/.github/workflows/test-failure.yaml
+++ b/.github/workflows/test-failure.yaml
@@ -1,0 +1,35 @@
+name: Test errors
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  no-conda:
+    name: No conda or mamba binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+
+      - name: Run action
+        uses: ./
+        id: run-action
+        with:
+          container-image: debian:latest  # Does not contain conda or mamba
+          environment-yaml-file: recipes/defaults/environment.yaml
+          recipe-directory: recipes/defaults
+        continue-on-error: true
+
+      - name: Error if successful
+        if: ${{ steps.run-action.outcome == 'success' }}
+        run: |
+          echo "::error::The build action succeeded unexpectedly."
+          exit 1
+        shell: bash

--- a/.github/workflows/test-failure.yaml
+++ b/.github/workflows/test-failure.yaml
@@ -2,6 +2,8 @@ name: Test errors
 
 on:
   pull_request:
+    paths:
+      - action.yaml
   push:
     branches:
       - main

--- a/.github/workflows/test-failure.yaml
+++ b/.github/workflows/test-failure.yaml
@@ -13,27 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate-input:
-    name: Input validation errors
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
-
-      - name: Run action
-        uses: ./
-        id: run-action
-        with:
-          input-directory: recipes/defaults
-        continue-on-error: true
-
-      - name: Error if successful
-        if: ${{ steps.run-action.outcome == 'success' }}
-        run: |
-          echo "::error::The build action succeeded unexpectedly."
-          exit 1
-        shell: bash
-
   no-conda:
     name: No conda or mamba binary
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failure.yaml
+++ b/.github/workflows/test-failure.yaml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -19,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Run action
         uses: ./

--- a/.github/workflows/test-failure.yaml
+++ b/.github/workflows/test-failure.yaml
@@ -15,6 +15,139 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-conda-root-input:
+    # This test doubles as a template injection test.
+    # If the cat command is not escaped, the build will succeed.
+    name: conda-root directory does not exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@d2e6a045a86077fb6cad6f5adf368e9076ddaa8d       # v3.1.0
+        with:
+          activate-environment: ''
+          run-post: false
+
+      - name: Create file with conda-root location
+        run: echo "${{ env.CONDA }}" >> ${{ runner.temp }}/path.txt
+        shell: bash
+
+      - name: Run action
+        uses: ./
+        id: run-action
+        with:
+          conda-root: $(cat ${{ runner.temp }}/path.txt)
+          environment-yaml-file: recipes/defaults/environment.yaml
+          input-directory: recipes/defaults
+        continue-on-error: true
+
+      - name: Error if successful
+        if: ${{ steps.run-action.outcome == 'success' }}
+        run: |
+          echo "::error::The build action succeeded unexpectedly."
+          exit 1
+        shell: bash
+
+  validate-environment-yaml-input:
+    # This test doubles as a template injection test.
+    # If the cat command is not escaped, the build will succeed.
+    name: environment-yaml file does not exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Create file with environment-yaml location
+        run: echo "recipes/defaults/environment.yaml" >> ${{ runner.temp }}/path.txt
+        shell: bash
+
+      - name: Run action
+        uses: ./
+        id: run-action
+        with:
+          environment-yaml-file: $(cat ${{ runner.temp }}/path.txt)
+          input-directory: recipes/defaults
+        continue-on-error: true
+
+      - name: Error if successful
+        if: ${{ steps.run-action.outcome == 'success' }}
+        run: |
+          echo "::error::The build action succeeded unexpectedly."
+          exit 1
+        shell: bash
+
+  validate-input-directory-input:
+    # This test doubles as a template injection test.
+    # If the cat command is not escaped, the build will succeed.
+    name: input-directory does not exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Create file with input-directory location
+        run: echo "recipes/defaults" >> ${{ runner.temp }}/path.txt
+        shell: bash
+
+      - name: Run action
+        uses: ./
+        id: run-action
+        with:
+          environment-yaml-file: recipes/defaults/environment.yaml
+          input-directory: $(cat ${{ runner.temp }}/path.txt)
+        continue-on-error: true
+
+      - name: Error if successful
+        if: ${{ steps.run-action.outcome == 'success' }}
+        run: |
+          echo "::error::The build action succeeded unexpectedly."
+          exit 1
+        shell: bash
+
+  validate-standalone-location-input:
+    # This test doubles as a template injection test.
+    # If the cat command is not escaped, the build will succeed.
+    name: standalone-location file does not exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Download micromamba
+        uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc  # v2.0.4
+        with:
+          init-shell: none
+
+      - name: Create file with standalone binary location
+        run: echo "${{ env.MAMBA_EXE }}" >> ${{ runner.temp }}/path.txt
+        shell: bash
+
+      - name: Run action
+        uses: ./
+        id: run-action
+        with:
+          environment-yaml-file: recipes/defaults/environment.yaml
+          input-directory: recipes/defaults
+          standalone-location: $(cat ${{ runner.temp }}/path.txt)
+        continue-on-error: true
+
+      - name: Error if successful
+        if: ${{ steps.run-action.outcome == 'success' }}
+        run: |
+          echo "::error::The build action succeeded unexpectedly."
+          exit 1
+        shell: bash
+
   no-conda:
     name: No conda or mamba binary
     runs-on: ubuntu-latest

--- a/.github/workflows/test-failure.yaml
+++ b/.github/workflows/test-failure.yaml
@@ -11,6 +11,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-input:
+    name: Input validation errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+
+      - name: Run action
+        uses: ./
+        id: run-action
+        with:
+          recipe-directory: recipes/defaults
+        continue-on-error: true
+
+      - name: Error if successful
+        if: ${{ steps.run-action.outcome == 'success' }}
+        run: |
+          echo "::error::The build action succeeded unexpectedly."
+          exit 1
+        shell: bash
+
   no-conda:
     name: No conda or mamba binary
     runs-on: ubuntu-latest

--- a/.github/workflows/test-file.yaml
+++ b/.github/workflows/test-file.yaml
@@ -1,0 +1,75 @@
+name: Test from environment.yaml file
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-installer:
+    name: Test from environment.yaml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830       # v3.1.1
+        with:
+          activate-environment: ''
+          run-post: false
+
+      - name: Create installer
+        id: create-installer
+        uses: ./
+        with:
+          conda-root: ${{ env.CONDA }}
+          environment-yaml-file: recipes/defaults/environment.yaml
+          recipe-directory: recipes/defaults
+
+      - name: Upload installer to Github artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2
+        with:
+          path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
+          name: signing-test
+          retention-days: 5
+
+      - name: Determine installer file name
+        id: installer-file
+        run: |
+          INSTALLER_FILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.sh" | head -n 1)
+          echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Verify hashes
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+          INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
+        run: |
+          cd ${ARTIFACTS_DIRECTORY}
+          sha256sum -c "${INSTALLER_FILE}.sha256"
+        shell: bash
+
+      - name: Run installer
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830       # v3.1.1
+        with:
+          activate-environment: ''
+          installation-dir: ${{ runner.temp }}/installer_test
+          installer-url: file://${{ steps.installer-file.outputs.installer-file }}
+
+      - name: Test installer
+        env:
+          INSTALL_DIR: ${{ runner.temp }}/installer_test
+        run: |
+          . ${CONDA}/etc/profile.d/conda.sh
+          conda activate
+          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')) == Path(info['root_prefix'])"
+          if [[ $(uname) == MINGW* ]]; then
+              test -f "${CONDA}/install.log"
+          fi
+        shell: bash

--- a/.github/workflows/test-file.yaml
+++ b/.github/workflows/test-file.yaml
@@ -49,8 +49,10 @@ jobs:
 
       - name: Determine installer file name
         id: installer-file
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
         run: |
-          INSTALLER_FILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.sh" | head -n 1)
+          INSTALLER_FILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.sh" | head -n 1)
           echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
         shell: bash
 

--- a/.github/workflows/test-file.yaml
+++ b/.github/workflows/test-file.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           . ${CONDA}/etc/profile.d/conda.sh
           conda activate
-          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')) == Path(info['root_prefix'])"
+          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')).samefile(info['root_prefix'])"
           if [[ $(uname) == MINGW* ]]; then
               test -f "${CONDA}/install.log"
           fi

--- a/.github/workflows/test-file.yaml
+++ b/.github/workflows/test-file.yaml
@@ -2,6 +2,10 @@ name: Test from environment.yaml file
 
 on:
   pull_request:
+    paths:
+      - action.yaml
+      - recipes/defaults/*
+      - .github/workflows/test-file.yaml
   push:
     branches:
       - main

--- a/.github/workflows/test-file.yaml
+++ b/.github/workflows/test-file.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           conda-root: ${{ env.CONDA }}
           environment-yaml-file: recipes/defaults/environment.yaml
-          recipe-directory: recipes/defaults
+          input-directory: recipes/defaults
 
       - name: Upload installer to Github artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2

--- a/.github/workflows/test-file.yaml
+++ b/.github/workflows/test-file.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -21,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830       # v3.1.1

--- a/.github/workflows/test-micromamba.yaml
+++ b/.github/workflows/test-micromamba.yaml
@@ -48,7 +48,7 @@ jobs:
               ${{ matrix.os == 'macos' && 'CONDA_OVERRIDE_OSX: 11.0' || '' }}
               ${{ matrix.os == 'ubuntu' && 'CONDA_OVERRIDE_GLIBC: 2.17' || '' }}
           standalone-location: ${{ env.MAMBA_EXE }}
-          recipe-directory: recipes/micromamba
+          input-directory: recipes/micromamba
 
       - name: Upload installer to Github artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2

--- a/.github/workflows/test-micromamba.yaml
+++ b/.github/workflows/test-micromamba.yaml
@@ -88,7 +88,7 @@ jobs:
         run: |
           . ${CONDA}/etc/profile.d/conda.sh
           conda activate
-          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')) == Path(info['root_prefix'])"
+          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')).samefile(info['root_prefix'])"
           conda config --show --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert 'conda-forge' in info['channels']"
           test "$(${CONDA}/_conda --version)" == "${MICROMAMBA_VERSION}"
         shell: bash

--- a/.github/workflows/test-micromamba.yaml
+++ b/.github/workflows/test-micromamba.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}

--- a/.github/workflows/test-micromamba.yaml
+++ b/.github/workflows/test-micromamba.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -28,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Download micromamba
         uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc  # v2.0.4

--- a/.github/workflows/test-micromamba.yaml
+++ b/.github/workflows/test-micromamba.yaml
@@ -1,0 +1,91 @@
+name: Test Micromamba
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-installer:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos]
+    name: Micromamba, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      MICROMAMBA_VERSION: 2.0.8
+      MICROMAMBA_BUILD: 0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+
+      - name: Download micromamba
+        uses: mamba-org/setup-micromamba@0dea6379afdaffa5d528b3d1dabc45da37f443fc  # v2.0.4
+        with:
+          init-shell: none
+          micromamba-version: ${{ env.MICROMAMBA_VERSION }}-${{ env.MICROMAMBA_BUILD }}
+
+      - name: Create installer
+        id: create-installer
+        uses: ./
+        with:
+          environment-yaml-string: |
+            channels:
+              - conda-forge
+            dependencies:
+              - constructor
+            variables:
+              ${{ matrix.os == 'macos' && 'CONDA_OVERRIDE_OSX: 11.0' || '' }}
+              ${{ matrix.os == 'ubuntu' && 'CONDA_OVERRIDE_GLIBC: 2.17' || '' }}
+          standalone-location: ${{ env.MAMBA_EXE }}
+          recipe-directory: recipes/micromamba
+
+      - name: Upload installer to Github artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2
+        with:
+          path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
+          name: test-micromamba-${{ matrix.os }}
+          retention-days: 5
+
+      - name: Determine installer file name
+        id: installer-file
+        run: |
+          INSTALLER_FILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.sh" | head -n 1)
+          echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Verify hashes
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+          INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
+        run: |
+          UNAME=$(uname)
+          [[ "${UNAME}" == "Darwin" ]] && SHACMD="shasum -a 256" || SHACMD=sha256sum
+          cd ${ARTIFACTS_DIRECTORY}
+          ${SHACMD} -c "${INSTALLER_FILE}.sha256"
+        shell: bash
+
+      - name: Run installer
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830       # v3.1.1
+        with:
+          activate-environment: ''
+          installation-dir: ${{ runner.temp }}/installer_test
+          installer-url: file://${{ steps.installer-file.outputs.installer-file }}
+
+      - name: Test installer
+        env:
+          INSTALL_DIR: ${{ runner.temp }}/installer_test
+        run: |
+          . ${CONDA}/etc/profile.d/conda.sh
+          conda activate
+          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')) == Path(info['root_prefix'])"
+          conda config --show --json | python -c "import sys, json; info = json.loads(sys.stdin.read()); assert 'conda-forge' in info['channels']"
+          test "$(${CONDA}/_conda --version)" == "${MICROMAMBA_VERSION}"
+        shell: bash

--- a/.github/workflows/test-micromamba.yaml
+++ b/.github/workflows/test-micromamba.yaml
@@ -2,6 +2,10 @@ name: Test Micromamba
 
 on:
   pull_request:
+    paths:
+      - action.yaml
+      - recipes/micromamba/*
+      - .github/workflows/test-micromamba.yaml
   push:
     branches:
       - main

--- a/.github/workflows/test-micromamba.yaml
+++ b/.github/workflows/test-micromamba.yaml
@@ -63,8 +63,10 @@ jobs:
 
       - name: Determine installer file name
         id: installer-file
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
         run: |
-          INSTALLER_FILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.sh" | head -n 1)
+          INSTALLER_FILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.sh" | head -n 1)
           echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
         shell: bash
 

--- a/.github/workflows/test-signing.yaml
+++ b/.github/workflows/test-signing.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -21,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up signing
         run: |

--- a/.github/workflows/test-signing.yaml
+++ b/.github/workflows/test-signing.yaml
@@ -2,6 +2,10 @@ name: Test signing installers
 
 on:
   pull_request:
+    paths:
+      - action.yaml
+      - recipes/defaults/construct.yaml
+      - .github/workflows/test-signing.yaml
   push:
     branches:
       - main

--- a/.github/workflows/test-signing.yaml
+++ b/.github/workflows/test-signing.yaml
@@ -76,7 +76,7 @@ jobs:
               EXT: exe
               NSIS_USING_LOG_BUILD: 1
           conda-root: ${{ env.CONDA }}
-          recipe-directory: recipes/defaults
+          input-directory: recipes/defaults
           constructor-pfx-certificate-password: ${{ steps.setup-signing.outputs.cert-password }}
 
       - name: Upload installer to Github artifact

--- a/.github/workflows/test-signing.yaml
+++ b/.github/workflows/test-signing.yaml
@@ -92,22 +92,20 @@ jobs:
 
       - name: Determine installer file name
         id: installer-file
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
         run: |
-          INSTALLER_FILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.exe" | head -n 1)
-          echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
-        shell: bash
+          $INSTALLER_FILE=$(Get-ChildItem -Path "${env:ARTIFACTS_DIRECTORY}" -Filter "*.exe")[0].FullName
+          echo "installer-file=${INSTALLER_FILE}" >> ${env:GITHUB_OUTPUT}
+        shell: pwsh
 
       - name: Verify hashes
         env:
           ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
           INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
         run: |
-          UNAME=$(uname)
           ARTIFACTS_DIRECTORY=$(cygpath "${ARTIFACTS_DIRECTORY}")
           cd ${ARTIFACTS_DIRECTORY}
-          if [[ $(uname) == MINGW* ]]; then
-              sed -i 's/\r//' "${INSTALLER_FILE}.sha256"
-          fi
           sha256sum -c "${INSTALLER_FILE}.sha256"
         shell: bash
 

--- a/.github/workflows/test-signing.yaml
+++ b/.github/workflows/test-signing.yaml
@@ -1,4 +1,4 @@
-name: Test signing
+name: Test signing installers
 
 on:
   pull_request:

--- a/.github/workflows/test-signing.yaml
+++ b/.github/workflows/test-signing.yaml
@@ -1,0 +1,114 @@
+name: Test signing
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-installer:
+    name: Signing installers
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+
+      - name: Set up signing
+        run: |
+          $signtool=(
+              Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -ErrorAction SilentlyContinue |
+                  Where-Object {$_.Name -eq "signtool.exe" -and $_.Directory.Name -eq "${{ runner.arch }}".ToLower() } |
+                  Sort-Object -Descending |
+                  Select-Object -First 1
+          )
+          if (!($signtool)) {
+              WriteError "Could not find signtool.exe on runner." -ErrorAction Stop
+          }
+          "signtool-path=${signtool.FullName}" | Out-File "${env:GITHUB_OUTPUT}" -Append
+
+          $certPassword=Get-Random
+          $certPath=
+          $certSplat = @{
+              DnsName = 'installers@conda.io'
+              Type = 'CodeSigning'
+              NotAfter = (Get-Date).AddDays(14)
+              CertStoreLocation = 'cert:\CurrentUser\My'
+          }
+          $pfxSplat = @{
+              Cert = New-SelfSignedCertificate @certSplat
+              FilePath = $certPath
+              Password = ConvertTo-SecureString -String "$certPassword" -Force -AsPlainText
+          }
+          Export-PfxCertificate @pfxSplat
+
+          "cert-path=${certPath}" | Out-File "${env:GITHUB_OUTPUT}" -Append
+          "cert-password=${certPassword}" | Out-File "${env:GITHUB_OUTPUT}" -Append
+        shell: pwsh
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830       # v3.1.1
+        with:
+          activate-environment: ''
+          run-post: false
+
+      - name: Create installer
+        id: create-installer
+        uses: ./
+        with:
+          environment-yaml-string: |
+            channels:
+              - defaults
+            dependencies:
+              - constructor
+              - nsis=*=*_log_*
+            variables:
+              CERTIFICATE_PATH: ${{ steps.setup-signing.outputs.cert-path }}
+              CONSTRUCTOR_SIGNTOOL_PATH: ${{ steps.setup-signing.outputs.signtool-path }}
+              EXT: exe
+              NSIS_USING_LOG_BUILD: 1
+          conda-root: ${{ env.CONDA }}
+          recipe-directory: recipes/defaults
+          constructor-pfx-certificate-password: ${{ steps.setup-signing.outputs.cert-password }}
+
+      - name: Upload installer to Github artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2
+        with:
+          path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
+          name: signing-test
+          retention-days: 5
+
+      - name: Determine installer file name
+        id: installer-file
+        run: |
+          INSTALLER_FILE=$(find "${{ steps.create-installer.outputs.artifacts-directory }}" -name "*.exe" | head -n 1)
+          echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Verify hashes
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+          INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
+        run: |
+          UNAME=$(uname)
+          ARTIFACTS_DIRECTORY=$(cygpath "${ARTIFACTS_DIRECTORY}")
+          cd ${ARTIFACTS_DIRECTORY}
+          if [[ $(uname) == MINGW* ]]; then
+              sed -i 's/\r//' "${INSTALLER_FILE}.sha256"
+          fi
+          sha256sum -c "${INSTALLER_FILE}.sha256"
+        shell: bash
+
+      - name: Verify signature
+        env:
+          INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
+        run: |
+          $sig=(Get-AuthenticodeSignature -LiteralPath "${env:INSTALLER_FILE}")
+          if ($sig.SignerCertificate.Thumbprint -eq "") {
+              Write-Error "Installer not signed." -ErrorAction Stop
+          }
+        shell: pwsh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,57 +1,57 @@
----
 # Apply to all files without commiting:
 #   pre-commit run --all-files
 # Update this file:
 #   pre-commit autoupdate
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v5.0.0
-      hooks:
-          - id: check-added-large-files
-          - id: check-ast
-          - id: fix-byte-order-marker
-          - id: check-case-conflict
-          - id: check-executables-have-shebangs
-          - id: check-merge-conflict
-          - id: check-shebang-scripts-are-executable
-          - id: check-yaml
-          - id: debug-statements
-          - id: detect-private-key
-          - id: end-of-file-fixer
-          - id: mixed-line-ending
-          - id: trailing-whitespace
-    - repo: https://github.com/PyCQA/isort
-      rev: 6.0.1
-      hooks:
-          - id: isort
-    - repo: https://github.com/psf/black
-      rev: 25.1.0
-      hooks:
-          - id: black
-    - repo: https://github.com/asottile/pyupgrade
-      rev: v3.19.1
-      hooks:
-          - id: pyupgrade
-            args: [--py37-plus, --keep-runtime-typing]
-    - repo: https://github.com/pycqa/flake8
-      rev: 7.2.0
-      hooks:
-          - id: flake8
-    - repo: https://github.com/lovesegfault/beautysh
-      rev: v6.2.1
-      hooks:
-          - id: beautysh
-    - repo: https://github.com/shellcheck-py/shellcheck-py
-      rev: v0.10.0.1
-      hooks:
-          - id: shellcheck
-    - repo: https://github.com/python-jsonschema/check-jsonschema
-      rev: 0.33.0
-      hooks:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.19.1
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus, --keep-runtime-typing]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/lovesegfault/beautysh
+    rev: v6.2.1
+    hooks:
+      - id: beautysh
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.33.0
+    hooks:
           # verify github syntaxes
-          - id: check-github-actions
-          - id: check-github-workflows
-    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.2.3
-      hooks:
-          - id: yamlfmt
+      - id: check-github-actions
+      - id: check-github-workflows
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.3
+    hooks:
+      - id: yamlfmt
+        args: [--mapping, '2', --offset, '2', --sequence, '4', --implicit_start]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
       - id: check-merge-conflict
       - id: check-shebang-scripts-are-executable
       - id: check-yaml
+        exclude: construct\.yaml
       - id: debug-statements
       - id: detect-private-key
       - id: end-of-file-fixer
@@ -54,4 +55,5 @@ repos:
     rev: 0.2.3
     hooks:
       - id: yamlfmt
+        exclude: construct\.yaml
         args: [--mapping, '2', --offset, '2', --sequence, '4', --implicit_start]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,3 @@
-# Apply to all files without commiting:
-#   pre-commit run --all-files
-# Update this file:
-#   pre-commit autoupdate
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -20,35 +16,9 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
-    hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
-    hooks:
-      - id: pyupgrade
-        args: [--py37-plus, --keep-runtime-typing]
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.2.0
-    hooks:
-      - id: flake8
-  - repo: https://github.com/lovesegfault/beautysh
-    rev: v6.2.1
-    hooks:
-      - id: beautysh
-  - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
-    hooks:
-      - id: shellcheck
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.33.0
     hooks:
-          # verify github syntaxes
       - id: check-github-actions
       - id: check-github-workflows
   - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       hooks:
           - id: shellcheck
     - repo: https://github.com/python-jsonschema/check-jsonschema
-      rev: 0.32.1
+      rev: 0.33.0
       hooks:
           # verify github syntaxes
           - id: check-github-actions

--- a/README.md
+++ b/README.md
@@ -1,8 +1,170 @@
 # Conda Installer
 
-The conda team to work on tools, techniques and documentation about conda installers such as miniconda, miniforge etc.
+This action creates [constructor](https://github.com/conda/constructor)-based installers.
+It creates a `conda` or `mamba` environment based on a supplied `environment.yaml` file
+and runs `constructor` to create the installer. It outputs the directory containing the build
+artifacts.
+
+For all available input parameters, see the [`action.yaml`](action.yaml) file.
+For full usage examples, see the [test workflows](.github/workflows).
+
+## Usage
+
+### Basic usage
+
+```yaml
+- name: Build installer
+  id: build
+  uses: conda-incubator/installer
+  with:
+    environment-yaml-file: environment.yaml
+    recipe-directory: recipe
+- name: Check output
+  run:
+    ls -la "${{ steps.build.outputs.artifacts-directory }}"
+```
+
+The action requires two input parameters:
+
+* `environment-yaml-file`: The file containing channels, dependencies, and environment variables
+                           for the installer build environment. `constructor` must be part of the
+                           dependency list.
+                           The content of that file can also be
+                           [supplied as a string](#using-a-string-instead-of-an-environment-file).
+* `recipe-directory`: The directory containing the `construct.yaml` file.
+
+The output of the action is the directory containing the build artifacts, i.e., the installers and
+other output files requested in the `construct.yaml`.
+
+### Using a string instead of an environment file
+
+The content of an `environment.yaml` file can also be input directly into the action.
+This is useful for using expressions to conditionally set the content of the file as opposed
+to having separate YAML files.
+
+```yaml
+- uses: conda-incubator/installer
+  with:
+    environment-yaml-string: |
+      channels:
+        - conda-forge
+      dependencies:
+        - constructor
+      variables:
+        EXT: ${{ runner.os == 'Windows' && 'exe' || 'sh' }}
+    recipe-directory: recipe
+```
+
+> [!NOTE]
+> The `environment-yaml-file` input takes precedence over `environment-yaml-string`.
+
+### Specifying the conda/mamba location
+
+If the `conda`/`mamba` are installed, but not in `PATH`, the location of the installation
+directory to create the build environment can be specified directly.
+
+```yaml
+- uses: conda-incubator/installer
+  with:
+    conda-root: ${{ env.CONDA }}
+    recipe-directory: recipe
+```
+
+### Using a different bootstrapper
+
+By default, `constructor` uses `conda-standalone` installed into the build environment.
+A different binary can be supplied via the `--conda-exe` input flag.
+The location to that binary can be set via the `standalone-location` input.
+
+
+```yaml
+- uses: conda-incubator/installer
+  with:
+    recipe-directory: recipe
+    standalone-location: ${{ runner.temp }}/mamba/micromamba
+```
+
+The standalone executable is also used to create the build environment if `conda`/`mamba` is not
+in `PATH` and `conda-root` is not set.
+
+### Building inside a container
+
+> [!NOTE]
+> This feature is only supported using Docker on Linux.
+
+Installers can be build inside a container.
+
+```yaml
+- uses: conda-incubator/installer
+  with:
+    environment-yaml-file: environment.yaml
+    container-arch: linux/arm64
+    container-image: condaforge/linux-anvil-aarch64
+    recipe-directory: recipe
+```
+
+The container must contain an instance of `conda` or `mamba`.
+The location can be supplied in three different ways:
+
+1. By having `conda`/`mamba` available via the `PATH` environment variable.
+1. By setting `conda-root` to the installation directory inside the image.
+1. Via the `standalone-location` input. The input refers to the location of the standalone binary
+   at the host. The directory will be mounted into the container.
+
+### Signing Windows installers
+
+Signing Windows installers with `constructor` requires secrets.
+To avoid writing secrets into an `environment.yaml` file, these secrets can be input directly.
+For a full list of supported secrets, see the [`action.yaml`](action.yaml) file.
+
+```yaml
+- uses: conda-incubator/installer
+  with:
+    constructor-pfx-certificate-password: ${{ secrets.pfx-password }}
+    environment-yaml-string: |
+      channels:
+        - conda-forge
+      dependencies:
+        - constructor
+      variables:
+          CONSTRUCTOR_SIGNTOOL_PATH: C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe
+    recipe-dir: recipe
+```
+
+## Build status
+
+| Workflow Status                                              |
+| ------------------------------------------------------------ |
+| [![Test container builds][ex-container-badge]][ex-container] |
+| [![Test defaults][ex-defaults-badge]][ex-defaults]           |
+| [![Test from environment.yaml file][ex-file-badge]][ex-file] |
+| [![Test Micromamba][ex-micromamba-badge]][ex-micromamba]     |
+| [![Test signing installers][ex-signing-badge]][ex-signing]   |
+
+[ex-container]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-container.yaml
+[ex-container-badge]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-container.yaml/badge.svg?branch=main
+[ex-defaults]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-defaults.yaml
+[ex-defaults-badge]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-defaults.yaml/badge.svg?branch=main
+[ex-file]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-file.yaml
+[ex-file-badge]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-file.yaml/badge.svg?branch=main
+[ex-micromamba]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-micromamba.yaml
+[ex-micromamba-badge]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-micromamba.yaml/badge.svg?branch=main
+[ex-signing]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-signing.yaml
+[ex-signing-badge]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-signing.yaml/badge.svg?branch=main
 
 ## Team charter
+
+The conda team to work on tools, techniques and documentation about conda installers such as miniconda, miniforge etc.
 
 The team charter is dynamic following the conda governance policy, with the following caveats:
 

--- a/README.md
+++ b/README.md
@@ -169,8 +169,6 @@ For a full list of supported secrets, see the [`action.yaml`](action.yaml) file.
 
 ## Team charter
 
-The conda team to work on tools, techniques and documentation about conda installers such as miniconda, miniforge etc.
-
 The team charter is dynamic following the conda governance policy, with the following caveats:
 
 - 🧰 The team’s purpose is to develop and maintain code included in the conda/installer repository. That repository contains among other things tools and scripts to make it incredibly easy to create and maintain installers similar to the current “miniconda” or “miniforge” installers.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ For a full list of supported secrets, see the [`action.yaml`](action.yaml) file.
 | [![Test from environment.yaml file][ex-file-badge]][ex-file] |
 | [![Test Micromamba][ex-micromamba-badge]][ex-micromamba]     |
 | [![Test signing installers][ex-signing-badge]][ex-signing]   |
+| [![Test expected failures][ex-failures-badge]][ex-failures]  |
 
 [ex-container]:
   https://github.com/conda-incubator/installer/actions/workflows/test-container.yaml
@@ -149,6 +150,10 @@ For a full list of supported secrets, see the [`action.yaml`](action.yaml) file.
   https://github.com/conda-incubator/installer/actions/workflows/test-defaults.yaml
 [ex-defaults-badge]:
   https://github.com/conda-incubator/installer/actions/workflows/test-defaults.yaml/badge.svg?branch=main
+[ex-failure]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-failure.yaml
+[ex-failure-badge]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-failure.yaml/badge.svg?branch=main
 [ex-file]:
   https://github.com/conda-incubator/installer/actions/workflows/test-file.yaml
 [ex-file-badge]:

--- a/action.yaml
+++ b/action.yaml
@@ -136,7 +136,7 @@ runs:
         CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD: ${{ inputs.constructor-pfx-certificate_password }}
       run: |
         echo "::group::Create environment"
-        # Define variables here instead of in an enviorn
+        # Define variables here instead of in an enviornment to simplify Docker command
         CONSTRUCTOR_WORKSPACE="${{ steps.workspace.outputs.constructor-workspace }}"
         OUTPUTS_FILE="${{ steps.workspace.outputs.outputs-file }}"
         ENVIRONMENT_YAML="${{ inputs.environment-yaml-file || steps.environment-str.outputs.environment-yaml-file }}"

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,186 @@
+name: Create installer
+description: Build the installer from a recipe directory.
+
+inputs:
+  conda-root:
+    description: Location to a pre-installed conda/mamba installation.
+    required: false
+  container-arch:
+    description: The architecture of the Docker image if different from the host.
+    required: false
+  container-image:
+    description: The Docker image used to build the installer.
+    required: false
+  environment-yaml-file:
+    description: |
+      Path to the environment.yaml file used to create the build environment.
+      Takes precedence over envrionemnt-yaml-string.
+      The file must not have the `name` property.
+    required: false
+  environment-yaml-string:
+    description: |
+      Multi-line string containing the contents of the environment.yaml file used to create the
+      build environment. Can be used to include logic and expressions from the calling workflow.
+      The file must not have the `name` property.
+    required: false
+  recipe-directory:
+    description: The directory containing the recipe file.
+    required: true
+  standalone-location:
+    description: The location of the standalone binary executable.
+    required: false
+
+    # secrets needed by constructor
+  azure-signtool-key-vault-client-id:
+    description: Client ID of the Azure key vault.
+    required: false
+  azure-signtool-key-vault-certificate:
+    description: Certificate of the Azure key vault.
+    required: false
+  azure-signtool-key-vault-secret:
+    description: Secret for the Azure key vault.
+    required: false
+  azure-signtool-key-vault-tenant-id:
+    description: Tenant ID of the Azure key vault.
+    required: false
+  azure-signtool-key-vault-url:
+    description: URL to for the Azure key vault.
+    required: false
+  constructor-pfx-certificate-password:
+    description: Windows signing password.
+    required: false
+
+outputs:
+  artifacts-directory:
+    description: Directory containing the artifacts of the constructor run.
+    value: ${{ steps.outputs.outputs.artifacts-directory }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up workspace
+      id: workspace
+      run: |
+        UNAME="$(uname)"
+        CONSTRUCTOR_WORKSPACE="${{ runner.temp }}/_constructor_workdir"
+        if [[ "${UNAME}" == MINGW* ]]; then
+            CONSTRUCTOR_WORKSPACE=$(cygpath "${CONSTRUCTOR_WORKSPACE}")
+        fi
+        mkdir -p "${CONSTRUCTOR_WORKSPACE}"
+        chmod 777 "${CONSTRUCTOR_WORKSPACE}"
+        echo "constructor-workspace=${CONSTRUCTOR_WORKSPACE}" >> ${GITHUB_OUTPUT}
+        # To avoid permission issues with GITHUB_OUTPUTS inside Docker images,
+        # create an outputs file that can be dumped into the output in a separate step.
+        echo "outputs-file=${CONSTRUCTOR_WORKSPACE}/outputs.txt" >> ${GITHUB_OUTPUT}
+      shell: bash
+
+    - name: Create environment.yaml file
+      if: ${{ !inputs.environment-yaml-file }}
+      id: environment-str
+      env:
+        ENVIRONMENT_FILE: ${{ steps.workspace.outputs.constructor-workspace }}/environment.yaml
+      run: |
+        echo "${{ inputs.environment-yaml-string }}" > "${ENVIRONMENT_FILE}"
+        echo "environment-yaml-file=${ENVIRONMENT_FILE}" >> ${GITHUB_OUTPUT}
+      shell: bash
+
+    - name: Set up QEMU
+      if: ${{ inputs.container-image && inputs.container-arch }}
+      uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a     # v3.3.0
+      with:
+        # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
+        image: tonistiigi/binfmt:qemu-v8.1.5
+        platforms: ${{ inputs.container-arch }}
+
+    - name: Create container command
+      if: ${{ inputs.container-image }}
+      id: container
+      run: |
+        # To run the build action inside a container, three locations need to be mounted:
+        #   * The GitHub workspace to access the recipe.
+        #     Mount the entire workspace directory instead of the recipe directory in case
+        #     construct.yaml refers to resources outside the directory.
+        #   * The temp directory so that the container can execute the build script.
+        #   * The workspace of the installer build for the output files of constructor.
+        #   * The directory of the standalone binary, if needed.
+        DOCKER_CMD=(
+            docker run --rm
+            -v "${{ github.workspace }}:${{  github.workspace }}"
+            -v "${{ runner.temp }}:${{ runner.temp }}"
+            -v "${{ steps.workspace.outputs.constructor-workspace }}:${{ steps.workspace.outputs.constructor-workspace }}"
+            ${{ inputs.standalone-location && format('-v $(dirname {0}):$(dirname {0})', inputs.standalone-location) || '' }}
+            ${{ inputs.container-arch && format('--platform {0}', inputs.container-arch) || '' }}
+            -e GITHUB_WORKSPACE
+            ${{ inputs.container-image }}
+            /bin/bash -eo pipefail {0}
+        )
+        echo "container-command=${DOCKER_CMD[@]}" >> ${GITHUB_OUTPUT}
+      shell: bash
+
+    - name: Build installer
+      id: build
+      env:
+        AZURE_SIGNTOOL_KEY_VAULT_CLIENT_ID: ${{ inputs.azure-signtool-key-vault-client-id }}
+        AZURE_SIGNTOOL_KEY_VAULT_CERTIFICATE: ${{ inputs.azure-signtool-key-vault-certificate }}
+        AZURE_SIGNTOOL_KEY_VAULT_SECRET: ${{ inputs.azure-signtool-key-vault-secret }}
+        AZURE_SIGNTOOL_KEY_VAULT_TENANT_ID: ${{ inputs.azure-signtool-key-vault-tenant-id }}
+        AZURE_SIGNTOOL_KEY_VAULT_URL: ${{ inputs.azure-signtool-key-vault-url }}
+        CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD: ${{ inputs.constructor-pfx-certificate_password }}
+      run: |
+        echo "::group::Create environment"
+        # Define variables here instead of in an enviorn
+        CONSTRUCTOR_WORKSPACE="${{ steps.workspace.outputs.constructor-workspace }}"
+        OUTPUTS_FILE="${{ steps.workspace.outputs.outputs-file }}"
+        ENVIRONMENT_YAML="${{ inputs.environment-yaml-file || steps.environment-str.outputs.environment-yaml-file }}"
+        CONDA_ROOT="${{ inputs.conda-root }}"
+
+        UNAME=$(uname)
+        if [[ "${UNAME}" == MINGW* ]] && [[ -n "${CONDA_ROOT}" ]]; then
+          CONDA_ROOT=$(cygpath "${CONDA}")
+        fi
+        RECIPE_DIR="${{ inputs.recipe-directory }}"
+        STANDALONE_EXE="${{ inputs.standalone-location }}"
+
+        if [[ -d "${CONDA_ROOT}" ]]; then
+            . "${CONDA_ROOT}/etc/profile.d/conda.sh" && conda activate
+        fi
+        if [[ -n "$(command -v conda)" ]]; then
+            CONDA_BIN=conda
+        elif [[ -n "$(command -v mamba)" ]]; then
+            CONDA_BIN=mamba
+        elif [[ -n "${STANDALONE_EXE}" ]]; then
+            CONDA_BIN="${STANDALONE_EXE}"
+        else
+            echo "Could not find conda or mamba binary."
+            exit 1
+        fi
+
+        PREFIX="${CONSTRUCTOR_WORKSPACE}/constructor"
+        ${CONDA_BIN} env create -p "${PREFIX}" --file "${ENVIRONMENT_YAML}" -y
+        . "${PREFIX}/etc/profile.d/conda.sh" && conda activate
+        echo "::endgroup::"
+
+        echo "::group::Construct the installer"
+        ARTIFACTS_DIRECTORY="${CONSTRUCTOR_WORKSPACE}/build"
+        mkdir -p "${ARTIFACTS_DIRECTORY}"
+        EXTRA_CONSTRUCTOR_ARGS=""
+        if [[ -n "${STANDALONE_EXE}" ]]; then
+            EXTRA_CONSTRUCTOR_ARGS+=" --conda-exe ${STANDALONE_EXE}"
+        fi
+        constructor "${RECIPE_DIR}"\
+          --output-dir "${ARTIFACTS_DIRECTORY}"\
+          ${EXTRA_CONSTRUCTOR_ARGS}
+        echo "::endgroup::"
+
+        if [[ "${UNAME}" == MINGW* ]]; then
+            ARTIFACTS_DIRECTORY=$(cygpath -w "${ARTIFACTS_DIRECTORY}")
+        fi
+        echo "artifacts-directory=${ARTIFACTS_DIRECTORY}" >> ${OUTPUTS_FILE}
+      shell: ${{ steps.container.outputs.container-command || 'bash -eo pipefail {0}' }}
+
+    - name: Set outputs
+      id: outputs
+      env:
+        OUTPUTS_FILE: ${{ steps.workspace.outputs.outputs-file }}
+      run: cat "${OUTPUTS_FILE}" >> ${GITHUB_OUTPUT}
+      shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -146,7 +146,7 @@ runs:
         if [[ "${UNAME}" == MINGW* ]] && [[ -n "${CONDA_ROOT}" ]]; then
           CONDA_ROOT=$(cygpath "${CONDA}")
         fi
-        RECIPE_DIR="${{ inputs.recipe-directory }}"
+        RECIPE_DIR="${GITHUB_WORKSPACE}/${{ inputs.recipe-directory }}"
         STANDALONE_EXE="${{ inputs.standalone-location }}"
 
         if [[ -d "${CONDA_ROOT}" ]]; then

--- a/action.yaml
+++ b/action.yaml
@@ -247,14 +247,16 @@ runs:
       shell: bash
 
     - name: Fix permissions and ownership for files created with a container
-      if: ${{ inputs.container-image }}
+      if: ${{ inputs.container-image && always() }}
       env:
         CONSTRUCTOR_WORKSPACE: ${{ steps.workspace.outputs.constructor-workspace }}
         DEFAULT_PERMISSIONS: ${{ steps.workspace.outputs.default-mkdir-permissions }}
       run: |
-        chmod ${DEFAULT_PERMISSIONS} "${CONSTRUCTOR_WORKSPACE}"
-        SUDO=$(sudo -n true 2>/dev/null && printf %s sudo)
-        if ! ${SUDO} chown -R $(id -u):$(id -g) "${CONSTRUCTOR_WORKSPACE}"; then
-          echo "WARNING: could not change owner of artifact files."
+        if [[ -d "${CONSTRUCTOR_WORKSPACE}" ]]; then
+          chmod ${DEFAULT_PERMISSIONS} "${CONSTRUCTOR_WORKSPACE}"
+          SUDO=$(sudo -n true 2>/dev/null && printf %s sudo)
+          if ! ${SUDO} chown -R $(id -u):$(id -g) "${CONSTRUCTOR_WORKSPACE}"; then
+            echo "WARNING: could not change owner of artifact files."
+          fi
         fi
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -81,9 +81,10 @@ runs:
       if: ${{ !inputs.environment-yaml-file }}
       id: environment-str
       env:
+        ENVIRONMENT_YAML_STRING: ${{ inputs.environment-yaml-string }}
         ENVIRONMENT_FILE: ${{ steps.workspace.outputs.constructor-workspace }}/environment.yaml
       run: |
-        echo "${{ inputs.environment-yaml-string }}" > "${ENVIRONMENT_FILE}"
+        echo "${ENVIRONMENT_YAML_STRING}" > "${ENVIRONMENT_FILE}"
         echo "environment-yaml-file=${ENVIRONMENT_FILE}" >> ${GITHUB_OUTPUT}
       shell: bash
 
@@ -98,7 +99,18 @@ runs:
     - name: Create container command
       if: ${{ inputs.container-image }}
       id: container
+      env:
+        CONSTRUCTOR_WORKSPACE: ${{ steps.workspace.outputs.constructor-workspace }}
+        CONTAINER_ARCH: ${{ inputs.container-arch }}
+        CONTAINER_IMAGE: ${{ inputs.container-image }}
+        STANDALONE_LOCATION: ${{ inputs.standalone-location }}
       run: |
+        if [[ -n "${STANDALONE_LOCATION}" ]]; then
+            STANDALONE_MOUNT_ARG="-v $(dirname "${STANDALONE_LOCATION}"):$(dirname "${STANDALONE_LOCATION}")"
+        fi
+        if [[ -n "${CONTAINER_ARCH}" ]]; then
+            PLATFORM_ARG="--platform ${CONTAINER_ARCH}"
+        fi
         # To run the build action inside a container, three locations need to be mounted:
         #   * The GitHub workspace to access the input directory.
         #     Mount the entire workspace directory instead of just the input directory in case
@@ -108,13 +120,13 @@ runs:
         #   * The directory of the standalone binary, if needed.
         DOCKER_CMD=(
             docker run --rm
-            -v "${{ github.workspace }}:${{  github.workspace }}"
-            -v "${{ runner.temp }}:${{ runner.temp }}"
-            -v "${{ steps.workspace.outputs.constructor-workspace }}:${{ steps.workspace.outputs.constructor-workspace }}"
-            ${{ inputs.standalone-location && format('-v $(dirname {0}):$(dirname {0})', inputs.standalone-location) || '' }}
-            ${{ inputs.container-arch && format('--platform {0}', inputs.container-arch) || '' }}
+            -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}"
+            -v "${RUNNER_TEMP}:${RUNNER_TEMP}"
+            -v "${CONSTRUCTOR_WORKSPACE}:${CONSTRUCTOR_WORKSPACE}"
+            ${STANDALONE_MOUNT_ARG}
+            ${PLATFORM_ARG}
             -e GITHUB_WORKSPACE
-            ${{ inputs.container-image }}
+            ${CONTAINER_IMAGE}
             /bin/bash -eo pipefail {0}
         )
         echo "container-command=${DOCKER_CMD[@]}" >> ${GITHUB_OUTPUT}

--- a/action.yaml
+++ b/action.yaml
@@ -97,7 +97,7 @@ runs:
       uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a     # v3.3.0
       with:
         # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-        image: tonistiigi/binfmt:qemu-v8.1.5
+        image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
         platforms: ${{ inputs.container-arch }}
 
     - name: Create container command

--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: The architecture of the Docker image if different from the host.
     required: false
   container-image:
-    description: The Docker image used to build the installer.
+    description: The container image used to build the installer.
     required: false
   environment-yaml-file:
     description: |
@@ -88,6 +88,8 @@ runs:
 
     - name: Set up workspace
       id: workspace
+      env:
+        CONTAINER_IMAGE: ${{ inputs.container-image }}
       run: |
         UNAME="$(uname)"
         CONSTRUCTOR_WORKSPACE="${RUNNER_TEMP}/_constructor_workdir"
@@ -95,7 +97,17 @@ runs:
             CONSTRUCTOR_WORKSPACE=$(cygpath "${CONSTRUCTOR_WORKSPACE}")
         fi
         mkdir -p "${CONSTRUCTOR_WORKSPACE}"
-        chmod 777 "${CONSTRUCTOR_WORKSPACE}"
+        if [[ -n "${CONTAINER_IMAGE}" ]]; then
+          DEFAULT_PERMISSIONS=$(
+            stat -c "%a" "${CONSTRUCTOR_WORKSPACE}" 2>/dev/null \
+            || stat -f "%A" "${CONSTRUCTOR_WORKSPACE}" 2>/dev/null
+          )
+          # Make directory permissions permissive so that all users in the container
+          # can write to the workspace directory. Permissions will be reset after
+          # artifact creation.
+          chmod 777 "${CONSTRUCTOR_WORKSPACE}"
+          echo "default-mkdir-permissions=${DEFAULT_PERMISSIONS}" >> ${GITHUB_OUTPUT}
+        fi
         echo "constructor-workspace=${CONSTRUCTOR_WORKSPACE}" >> ${GITHUB_OUTPUT}
         # To avoid permission issues with GITHUB_OUTPUTS inside Docker images,
         # create an outputs file that can be dumped into the output in a separate step.
@@ -232,4 +244,17 @@ runs:
       env:
         OUTPUTS_FILE: ${{ steps.workspace.outputs.outputs-file }}
       run: cat "${OUTPUTS_FILE}" >> ${GITHUB_OUTPUT}
+      shell: bash
+
+    - name: Fix permissions and ownership for files created with a container
+      if: ${{ inputs.container-image }}
+      env:
+        CONSTRUCTOR_WORKSPACE: ${{ steps.workspace.outputs.constructor-workspace }}
+        DEFAULT_PERMISSIONS: ${{ steps.workspace.outputs.default-mkdir-permissions }}
+      run: |
+        chmod ${DEFAULT_PERMISSIONS} "${CONSTRUCTOR_WORKSPACE}"
+        SUDO=$(sudo -n true 2>/dev/null && printf %s sudo)
+        if ! ${SUDO} chown -R $(id -u):$(id -g) "${CONSTRUCTOR_WORKSPACE}"; then
+          echo "WARNING: could not change owner of artifact files."
+        fi
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -165,7 +165,6 @@ runs:
 
         PREFIX="${CONSTRUCTOR_WORKSPACE}/constructor"
         ${CONDA_BIN} env create -p "${PREFIX}" --file "${ENVIRONMENT_YAML}" -y
-        . "${PREFIX}/etc/profile.d/conda.sh" && conda activate
         echo "::endgroup::"
 
         echo "::group::Construct the installer"
@@ -175,9 +174,10 @@ runs:
         if [[ -n "${STANDALONE_EXE}" ]]; then
             EXTRA_CONSTRUCTOR_ARGS+=" --conda-exe ${STANDALONE_EXE}"
         fi
-        constructor "${RECIPE_DIR}"\
-          --output-dir "${ARTIFACTS_DIRECTORY}"\
-          ${EXTRA_CONSTRUCTOR_ARGS}
+        ${CONDA_BIN} run -p "${PREFIX}" \
+          constructor "${RECIPE_DIR}"\
+            --output-dir "${ARTIFACTS_DIRECTORY}"\
+            ${EXTRA_CONSTRUCTOR_ARGS}
         # Remove the constructor-generated tmp directory
         rm -rf "${ARTIFACTS_DIRECTORY}/tmp"
         echo "::endgroup::"

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: Create installer
-description: Build the installer from a recipe directory.
+description: Build the installer from an input directory.
 
 inputs:
   conda-root:
@@ -23,8 +23,8 @@ inputs:
       build environment. Can be used to include logic and expressions from the calling workflow.
       The file must not have the `name` property.
     required: false
-  recipe-directory:
-    description: The directory containing the recipe file.
+  input-directory:
+    description: The directory containing the construct.yaml file.
     required: true
   standalone-location:
     description: The location of the standalone binary executable.
@@ -105,8 +105,8 @@ runs:
       id: container
       run: |
         # To run the build action inside a container, three locations need to be mounted:
-        #   * The GitHub workspace to access the recipe.
-        #     Mount the entire workspace directory instead of the recipe directory in case
+        #   * The GitHub workspace to access the input directory.
+        #     Mount the entire workspace directory instead of just the input directory in case
         #     construct.yaml refers to resources outside the directory.
         #   * The temp directory so that the container can execute the build script.
         #   * The workspace of the installer build for the output files of constructor.
@@ -146,7 +146,7 @@ runs:
         if [[ "${UNAME}" == MINGW* ]] && [[ -n "${CONDA_ROOT}" ]]; then
           CONDA_ROOT=$(cygpath "${CONDA}")
         fi
-        RECIPE_DIR="${GITHUB_WORKSPACE}/${{ inputs.recipe-directory }}"
+        INPUT_DIR="${GITHUB_WORKSPACE}/${{ inputs.input-directory }}"
         STANDALONE_EXE="${{ inputs.standalone-location }}"
 
         if [[ -d "${CONDA_ROOT}" ]]; then
@@ -175,7 +175,7 @@ runs:
             EXTRA_CONSTRUCTOR_ARGS+=" --conda-exe ${STANDALONE_EXE}"
         fi
         ${CONDA_BIN} run -p "${PREFIX}" \
-          constructor "${RECIPE_DIR}"\
+          constructor "${INPUT_DIR}"\
             --output-dir "${ARTIFACTS_DIRECTORY}"\
             ${EXTRA_CONSTRUCTOR_ARGS}
         # Remove the constructor-generated tmp directory

--- a/action.yaml
+++ b/action.yaml
@@ -15,13 +15,16 @@ inputs:
     description: |
       Path to the environment.yaml file used to create the build environment.
       Takes precedence over environment-yaml-string.
-      The file must not have the `name` property.
     required: false
   environment-yaml-string:
+    default: |
+      channels:
+        - conda-forge
+      dependencies:
+        - constructor
     description: |
       Multi-line string containing the contents of the environment.yaml file used to create the
       build environment. Can be used to include logic and expressions from the calling workflow.
-      The file must not have the `name` property.
     required: false
   input-directory:
     description: The directory containing the construct.yaml file.
@@ -58,14 +61,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Validate input
-      run: |
-        if [[ -z "${{ inputs.environment-yaml-file }}" ]] && [[ -z "${{ inputs.environment-yaml-string }}" ]]; then
-          echo "::error::\`environment-yaml-file\` or \`environment-yaml-string\` must be set."
-          exit 1
-        fi
-      shell: bash
-
     - name: Set up workspace
       id: workspace
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -144,15 +144,23 @@ runs:
         INPUT_DIR="${GITHUB_WORKSPACE}/${{ inputs.input-directory }}"
         STANDALONE_EXE="${{ inputs.standalone-location }}"
 
+        NO_CAPTURE_OUTPUT_FLAG=""
         if [[ -d "${CONDA_ROOT}" ]]; then
             . "${CONDA_ROOT}/etc/profile.d/conda.sh" && conda activate
         fi
         if [[ -n "$(command -v conda)" ]]; then
             CONDA_BIN=conda
+            NO_CAPTURE_OUTPUT_FLAG='--no-capture-output'
         elif [[ -n "$(command -v mamba)" ]]; then
             CONDA_BIN=mamba
+            NO_CAPTURE_OUTPUT_FLAG='--attach  ""'
         elif [[ -n "${STANDALONE_EXE}" ]]; then
             CONDA_BIN="${STANDALONE_EXE}"
+            if [[ "$("${CONDA_BIN}" --version | cut -d' ' -f1)" == "conda" ]]; then
+                NO_CAPTURE_OUTPUT_FLAG='--no-capture-output'
+            elif [[ -n "$("${CONDA_BIN}" --help | grep mamba)" ]]; then
+                NO_CAPTURE_OUTPUT_FLAG='--attach  ""'
+            fi
         else
             echo "::error::Could not find conda or mamba binary."
             exit 1
@@ -169,7 +177,7 @@ runs:
         if [[ -n "${STANDALONE_EXE}" ]]; then
             EXTRA_CONSTRUCTOR_ARGS+=" --conda-exe ${STANDALONE_EXE}"
         fi
-        ${CONDA_BIN} run -p "${PREFIX}" \
+        ${CONDA_BIN} run $NO_CAPTURE_OUTPUT_FLAG -p "${PREFIX}" \
           constructor "${INPUT_DIR}"\
             --output-dir "${ARTIFACTS_DIRECTORY}"\
             ${EXTRA_CONSTRUCTOR_ARGS}

--- a/action.yaml
+++ b/action.yaml
@@ -61,6 +61,31 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate input
+      env:
+        CONDA_ROOT: ${{ inputs.conda-root }}
+        ENVIRONMENT_YAML_FILE: ${{ inputs.environment-yaml-file }}
+        INPUT_DIRECTORY: ${{ inputs.input-directory }}
+        STANDALONE_LOCATION: ${{ inputs.standalone-location }}
+      run: |
+        if [[ -n "${CONDA_ROOT}" ]] && [[ ! -d "${CONDA_ROOT}" ]]; then
+            echo "::error::Directory ${CONDA_ROOT} does not exist."
+            exit 1
+        fi
+        if [[ -n "${ENVIRONMENT_YAML_FILE}" ]] && [[ ! -f "${ENVIRONMENT_YAML_FILE}" ]]; then
+            echo "::error::File ${ENVIRONMENT_YAML_FILE} does not exist."
+            exit 1
+        fi
+        if [[ -n "${INPUT_DIRECTORY}" ]] && [[ ! -d "${INPUT_DIRECTORY}" ]]; then
+            echo "::error::Directory ${INPUT_DIRECTORY} does not exist."
+            exit 1
+        fi
+        if [[ -n "${STANDALONE_LOCATION}" ]] && [[ ! -f "${STANDALONE_LOCATION}" ]]; then
+            echo "::error::File ${STANDALONE_LOCATION} does not exist."
+            exit 1
+        fi
+      shell: bash
+
     - name: Set up workspace
       id: workspace
       run: |
@@ -81,8 +106,8 @@ runs:
       if: ${{ !inputs.environment-yaml-file }}
       id: environment-str
       env:
-        ENVIRONMENT_YAML_STRING: ${{ inputs.environment-yaml-string }}
         ENVIRONMENT_FILE: ${{ steps.workspace.outputs.constructor-workspace }}/environment.yaml
+        ENVIRONMENT_YAML_STRING: ${{ inputs.environment-yaml-string }}
       run: |
         echo "${ENVIRONMENT_YAML_STRING}" > "${ENVIRONMENT_FILE}"
         echo "environment-yaml-file=${ENVIRONMENT_FILE}" >> ${GITHUB_OUTPUT}

--- a/action.yaml
+++ b/action.yaml
@@ -151,7 +151,7 @@ runs:
         elif [[ -n "${STANDALONE_EXE}" ]]; then
             CONDA_BIN="${STANDALONE_EXE}"
         else
-            echo "Could not find conda or mamba binary."
+            echo "::error::Could not find conda or mamba binary."
             exit 1
         fi
 

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ inputs:
     description: The location of the standalone binary executable.
     required: false
 
-    # secrets needed by constructor
+  # secrets needed by constructor
   azure-signtool-key-vault-client-id:
     description: Client ID of the Azure key vault.
     required: false
@@ -58,6 +58,14 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Validate input
+      run: |
+        if [[ -z "${{ inputs.environment-yaml-file }}" ]] && [[ -z "${{ inputs.environment-yaml-string }}" ]]; then
+          echo "::error::\`environment-yaml-file\` or \`environment-yaml-string\` must be set."
+          exit 1
+        fi
+      shell: bash
+
     - name: Set up workspace
       id: workspace
       run: |

--- a/action.yaml
+++ b/action.yaml
@@ -90,7 +90,7 @@ runs:
       id: workspace
       run: |
         UNAME="$(uname)"
-        CONSTRUCTOR_WORKSPACE="${{ runner.temp }}/_constructor_workdir"
+        CONSTRUCTOR_WORKSPACE="${RUNNER_TEMP}/_constructor_workdir"
         if [[ "${UNAME}" == MINGW* ]]; then
             CONSTRUCTOR_WORKSPACE=$(cygpath "${CONSTRUCTOR_WORKSPACE}")
         fi

--- a/action.yaml
+++ b/action.yaml
@@ -117,8 +117,7 @@ runs:
       if: ${{ inputs.container-image && inputs.container-arch }}
       uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a     # v3.3.0
       with:
-        # https://github.com/docker/setup-qemu-action/issues/188#issuecomment-2604322104
-        image: tonistiigi/binfmt:qemu-v8.1.5@sha256:2d2918e86e5327d0661f7083d67a95280b0f7be8f77ed79a8418f81d7d90ce6f
+        image: tonistiigi/binfmt:qemu-v9.2.2@sha256:1b804311fe87047a4c96d38b4b3ef6f62fca8cd125265917a9e3dc3c996c39e6
         platforms: ${{ inputs.container-arch }}
 
     - name: Create container command

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ inputs:
   environment-yaml-file:
     description: |
       Path to the environment.yaml file used to create the build environment.
-      Takes precedence over envrionemnt-yaml-string.
+      Takes precedence over environment-yaml-string.
       The file must not have the `name` property.
     required: false
   environment-yaml-string:
@@ -136,7 +136,7 @@ runs:
         CONSTRUCTOR_PFX_CERTIFICATE_PASSWORD: ${{ inputs.constructor-pfx-certificate_password }}
       run: |
         echo "::group::Create environment"
-        # Define variables here instead of in an enviornment to simplify Docker command
+        # Define variables here instead of in an environment to simplify Docker command
         CONSTRUCTOR_WORKSPACE="${{ steps.workspace.outputs.constructor-workspace }}"
         OUTPUTS_FILE="${{ steps.workspace.outputs.outputs-file }}"
         ENVIRONMENT_YAML="${{ inputs.environment-yaml-file || steps.environment-str.outputs.environment-yaml-file }}"

--- a/action.yaml
+++ b/action.yaml
@@ -178,6 +178,8 @@ runs:
         constructor "${RECIPE_DIR}"\
           --output-dir "${ARTIFACTS_DIRECTORY}"\
           ${EXTRA_CONSTRUCTOR_ARGS}
+        # Remove the constructor-generated tmp directory
+        rm -rf "${ARTIFACTS_DIRECTORY}/tmp"
         echo "::endgroup::"
 
         if [[ "${UNAME}" == MINGW* ]]; then

--- a/recipes/defaults/construct.yaml
+++ b/recipes/defaults/construct.yaml
@@ -1,0 +1,17 @@
+{% set installer_type = os.environ.get("EXT", "sh") %}
+{% set certificate_path = os.environ.get("CERTIFICATE_PATH", "") %}
+
+name: TestInstallerDefaults
+version: 0.0.1
+installer_type: {{ installer_type }}
+write_condarc: true
+{% if certificate_path %}
+signing_certificate: {{ certificate_path }}
+{% endif %}
+channels:
+  - http://repo.anaconda.com/pkgs/main/
+specs:
+  - conda
+build_outputs:
+  - hash:
+      algorithm: sha256

--- a/recipes/defaults/environment.yaml
+++ b/recipes/defaults/environment.yaml
@@ -1,0 +1,4 @@
+channels:
+  - defaults
+dependencies:
+  - constructor

--- a/recipes/micromamba/construct.yaml
+++ b/recipes/micromamba/construct.yaml
@@ -1,0 +1,14 @@
+{% set installer_type = os.environ.get("EXT", "sh") %}
+
+name: TestInstallerMicromamba
+version: 0.0.1
+installer_type: {{ installer_type }}
+write_condarc: True
+channels:
+  - conda-forge
+specs:
+  - conda
+  - mamba
+build_outputs:
+  - hash:
+      algorithm: sha256


### PR DESCRIPTION
This PR creates a composite action to build `constructor`-based installers. The goal of this action is to unify the build workflows for both Anaconda and Miniforge installers and pool maintenance resources.

The action takes or creates an `environment.yaml` to create a build environment. Inside that build environment, it runs `constructor` on a provided recipe directory to create the installer. The output directory contains all `constructor`-created build artifacts.

The workflow is intended to be flexible and can:

* Run the creation directly on a runner or inside a Docker container.
* Use GitHub expressions to dynamically set the content of the build environment.
* Can use existing `conda` installations on the runner/image or use `conda-standalone`/`micromamba` to create the build environment.
* Supports `constructor`'s interface for signing installers.

The README file contains several use cases and I added tests for each of them.

Closes #3 