### PR TITLE
 Activate environment instead of using `conda run`

### DIFF
--- a/.github/workflows/test-conda-standalone.yaml
+++ b/.github/workflows/test-conda-standalone.yaml
@@ -105,8 +105,8 @@ jobs:
         env:
           ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
         run: |
-          INSTALLER_FILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.sh" | head -n 1)
-          echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
+          SHAFILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.sha256" | head -n 1)
+          echo "installer-file=${SHAFILE/\.sha256/}" >> ${GITHUB_OUTPUT}
         shell: bash
 
       - name: Verify hashes

--- a/.github/workflows/test-conda-standalone.yaml
+++ b/.github/workflows/test-conda-standalone.yaml
@@ -1,0 +1,134 @@
+name: Test conda-standalone
+
+on:
+  pull_request:
+    paths:
+      - action.yaml
+      - recipes/defaults/*
+      - .github/workflows/test-conda-standalone.yaml
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-installer:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu
+            target-platform: linux-64
+          #- os: macos
+          #  target-plaftorm: osx-arm64
+          #- os: windows
+          #  target-platform: win-64
+    name: conda-standalone, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      CONDA_STANDALONE_VERSION: 25.1.1
+      CONDA_STANDALONE_BUILD: 0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683       # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Download conda-standalone
+        id: download-conda-standalone
+        env:
+          STANDALONE_DIR: ${{ runner.temp }}/_standalone
+          STANDALONE_VERSION: 25.1.1
+          TARGET_PLATFORM: ${{ matrix.target-platform }}
+        run: |
+          mkdir -p "${STANDALONE_DIR}"
+
+          # Find conda-standalone in repositoru
+          filepath=$(curl -s https://api.anaconda.org/package/main/conda-standalone/files \
+            | jq -r "map(select(.version==\"${STANDALONE_VERSION}\" and .attrs.subdir == \"${TARGET_PLATFORM}\")) | max_by(.attrs.build_number) | .basename" \
+          )
+           if [[ "${filepath}" == *.conda ]]; then
+              STANDALONE_ARCHIVE="${STANDALONE_DIR}/standalone.conda"
+          elif [[ "${filepath}" == *.tar.bz2 ]]; then
+              STANDALONE_ARCHIVE="${STANDALONE_DIR}/standalone.tar.bz2"
+          else
+              echo "Unregonized file format for ${filepath}"
+              exit 1
+          fi
+          curl -sL "https://conda.anaconda.org/main/${filepath}" -o "${STANDALONE_ARCHIVE}"
+
+          # Unpack and find the executable
+          tar -xf "${STANDALONE_ARCHIVE}" -C "${STANDALONE_DIR}"
+          if [[ "${STANDALONE_ARCHIVE}" == *.conda ]]; then
+              for tarfile in $(find "${STANDALONE_DIR}" -name "*.tar.zst"); do
+                  tar -xf "${tarfile}" -C "${STANDALONE_DIR}"
+              done
+          fi
+          STANDALONE_EXE=$(find "${STANDALONE_DIR}" -name "conda.exe")
+          echo "standalone-path=${STANDALONE_EXE}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Create installer
+        id: create-installer
+        uses: ./
+        with:
+          environment-yaml-file: recipes/defaults/environment.yaml
+          input-directory: recipes/defaults
+          standalone-location: ${{ steps.download-conda-standalone.outputs.standalone-path }}
+
+      #- name: Upload installer to Github artifact
+      #  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2
+      #  with:
+      #    path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
+      #    name: test-conda-standalone-${{ matrix.os }}
+      #    retention-days: 5
+
+      - name: Determine installer file name
+        id: installer-file
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+        run: |
+          INSTALLER_FILE=$(find "${ARTIFACTS_DIRECTORY}" -name "*.sh" | head -n 1)
+          echo "installer-file=${INSTALLER_FILE}" >> ${GITHUB_OUTPUT}
+        shell: bash
+
+      - name: Verify hashes
+        env:
+          ARTIFACTS_DIRECTORY: ${{ steps.create-installer.outputs.artifacts-directory }}
+          INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
+        run: |
+          UNAME=$(uname)
+          [[ "${UNAME}" == "Darwin" ]] && SHACMD="shasum -a 256" || SHACMD=sha256sum
+          cd ${ARTIFACTS_DIRECTORY}
+          ${SHACMD} -c "${INSTALLER_FILE}.sha256"
+        shell: bash
+
+      - name: Run installer
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830       # v3.1.1
+        with:
+          activate-environment: ''
+          installation-dir: ${{ runner.temp }}/installer_test
+          installer-url: file://${{ steps.installer-file.outputs.installer-file }}
+
+      - name: Test installer
+        env:
+          INSTALL_DIR: ${{ runner.temp }}/installer_test
+        run: |
+          if [[ $(uname) == MINGW* ]]; then
+              CONDA=$(cygpath "${CONDA}")
+          fi
+          . ${CONDA}/etc/profile.d/conda.sh
+          conda activate
+          conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')).samefile(info['root_prefix'])"
+          if [[ $(uname) == MINGW* ]]; then
+              test -f "${CONDA}/install.log"
+              test "$(${CONDA}/_conda.exe --version | cut -d' ' -f2)" == "${CONDA_STANDALONE_VERSION}"
+          else
+              test "$(${CONDA}/_conda --version | cut -d' ' -f2)" == "${CONDA_STANDALONE_VERSION}"
+          fi
+        shell: bash

--- a/.github/workflows/test-conda-standalone.yaml
+++ b/.github/workflows/test-conda-standalone.yaml
@@ -119,13 +119,14 @@ jobs:
         env:
           INSTALL_DIR: ${{ runner.temp }}/installer_test
         run: |
-          if [[ $(uname) == MINGW* ]]; then
+          UNAME="$(uname)"
+          if [[ "${UNAME}" == MINGW* ]]; then
               CONDA=$(cygpath "${CONDA}")
           fi
           . ${CONDA}/etc/profile.d/conda.sh
           conda activate
           conda info --json | python -c "import json, os, sys; from pathlib import Path; info = json.loads(sys.stdin.read()); assert Path(os.environ.get('INSTALL_DIR', '')).samefile(info['root_prefix'])"
-          if [[ $(uname) == MINGW* ]]; then
+          if [[ "${UNAME}" == MINGW* ]]; then
               test -f "${CONDA}/install.log"
               test "$(${CONDA}/_conda.exe --version | cut -d' ' -f2)" == "${CONDA_STANDALONE_VERSION}"
           else

--- a/.github/workflows/test-conda-standalone.yaml
+++ b/.github/workflows/test-conda-standalone.yaml
@@ -115,6 +115,7 @@ jobs:
           INSTALLER_FILE: ${{ steps.installer-file.outputs.installer-file }}
         run: |
           UNAME=$(uname)
+          [[ "${UNAME}" == MINGW* ]] && ARTIFACTS_DIRECTORY=$(cygpath "${ARTIFACTS_DIRECTORY}")
           [[ "${UNAME}" == "Darwin" ]] && SHACMD="shasum -a 256" || SHACMD=sha256sum
           cd ${ARTIFACTS_DIRECTORY}
           ${SHACMD} -c "${INSTALLER_FILE}.sha256"

--- a/.github/workflows/test-conda-standalone.yaml
+++ b/.github/workflows/test-conda-standalone.yaml
@@ -25,7 +25,7 @@ jobs:
           - os: ubuntu
             target-platform: linux-64
           - os: macos
-            target-plaftorm: osx-arm64
+            target-platform: osx-arm64
           - os: windows
             target-platform: win-64
     name: conda-standalone, ${{ matrix.os }}
@@ -46,6 +46,9 @@ jobs:
           STANDALONE_VERSION: 25.1.1
           TARGET_PLATFORM: ${{ matrix.target-platform }}
         run: |
+          if [[ "$(uname)" == MINGW* ]]; then
+              STANDALONE_DIR=$(cygpath "${STANDALONE_DIR}")
+          fi
           mkdir -p "${STANDALONE_DIR}"
 
           # Find conda-standalone in repositoru

--- a/.github/workflows/test-conda-standalone.yaml
+++ b/.github/workflows/test-conda-standalone.yaml
@@ -81,7 +81,16 @@ jobs:
         uses: ./
         with:
           environment-yaml-file: recipes/defaults/environment.yaml
-          input-directory: recipes/defaults
+          environment-yaml-string: |
+            channels:
+              - defaults
+            dependencies:
+              - constructor
+              ${{ matrix.os == 'windows' && '- nsis=*=*_log_*' || '' }}
+            variables:
+              ${{ matrix.os == 'macos' && 'CONDA_OVERRIDE_OSX: 12.0' || '' }}
+              EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
+              NSIS_USING_LOG_BUILD: 1
           standalone-location: ${{ steps.download-conda-standalone.outputs.standalone-path }}
 
       - name: Upload installer to Github artifact

--- a/.github/workflows/test-conda-standalone.yaml
+++ b/.github/workflows/test-conda-standalone.yaml
@@ -80,7 +80,6 @@ jobs:
         id: create-installer
         uses: ./
         with:
-          environment-yaml-file: recipes/defaults/environment.yaml
           environment-yaml-string: |
             channels:
               - defaults
@@ -91,6 +90,7 @@ jobs:
               ${{ matrix.os == 'macos' && 'CONDA_OVERRIDE_OSX: 12.0' || '' }}
               EXT: ${{ matrix.os == 'windows' && 'exe' || 'sh' }}
               NSIS_USING_LOG_BUILD: 1
+          input-directory: recipes/defaults
           standalone-location: ${{ steps.download-conda-standalone.outputs.standalone-path }}
 
       - name: Upload installer to Github artifact

--- a/.github/workflows/test-conda-standalone.yaml
+++ b/.github/workflows/test-conda-standalone.yaml
@@ -24,10 +24,10 @@ jobs:
         include:
           - os: ubuntu
             target-platform: linux-64
-          #- os: macos
-          #  target-plaftorm: osx-arm64
-          #- os: windows
-          #  target-platform: win-64
+          - os: macos
+            target-plaftorm: osx-arm64
+          - os: windows
+            target-platform: win-64
     name: conda-standalone, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
     env:
@@ -81,12 +81,12 @@ jobs:
           input-directory: recipes/defaults
           standalone-location: ${{ steps.download-conda-standalone.outputs.standalone-path }}
 
-      #- name: Upload installer to Github artifact
-      #  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2
-      #  with:
-      #    path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
-      #    name: test-conda-standalone-${{ matrix.os }}
-      #    retention-days: 5
+      - name: Upload installer to Github artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02       # v4.6.2
+        with:
+          path: ${{ steps.create-installer.outputs.artifacts-directory }}/*
+          name: test-conda-standalone-${{ matrix.os }}
+          retention-days: 5
 
       - name: Determine installer file name
         id: installer-file

--- a/README.md
+++ b/README.md
@@ -133,14 +133,15 @@ For a full list of supported secrets, see the [`action.yaml`](action.yaml) file.
 
 ## Build status
 
-| Workflow Status                                              |
-| ------------------------------------------------------------ |
-| [![Test container builds][ex-container-badge]][ex-container] |
-| [![Test defaults][ex-defaults-badge]][ex-defaults]           |
-| [![Test from environment.yaml file][ex-file-badge]][ex-file] |
-| [![Test Micromamba][ex-micromamba-badge]][ex-micromamba]     |
-| [![Test signing installers][ex-signing-badge]][ex-signing]   |
-| [![Test expected failures][ex-failures-badge]][ex-failures]  |
+| Workflow Status                                                            |
+| -------------------------------------------------------------------------- |
+| [![Test container builds][ex-container-badge]][ex-container]               |
+| [![Test defaults][ex-defaults-badge]][ex-defaults]                         |
+| [![Test from environment.yaml file][ex-file-badge]][ex-file]               |
+| [![Test conda-standalone][ex-conda-standalone-badge]][ex-conda-standalone] |
+| [![Test Micromamba][ex-micromamba-badge]][ex-micromamba]                   |
+| [![Test signing installers][ex-signing-badge]][ex-signing]                 |
+| [![Test expected failures][ex-failures-badge]][ex-failures]                |
 
 [ex-container]:
   https://github.com/conda-incubator/installer/actions/workflows/test-container.yaml
@@ -158,6 +159,10 @@ For a full list of supported secrets, see the [`action.yaml`](action.yaml) file.
   https://github.com/conda-incubator/installer/actions/workflows/test-file.yaml
 [ex-file-badge]:
   https://github.com/conda-incubator/installer/actions/workflows/test-file.yaml/badge.svg?branch=main
+[ex-conda-standalone]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-conda-standalone.yaml
+[ex-conda-standalone-badge]:
+  https://github.com/conda-incubator/installer/actions/workflows/test-conda-standalone.yaml/badge.svg?branch=main
 [ex-micromamba]:
   https://github.com/conda-incubator/installer/actions/workflows/test-micromamba.yaml
 [ex-micromamba-badge]:

--- a/action.yaml
+++ b/action.yaml
@@ -196,23 +196,15 @@ runs:
         INPUT_DIR="${GITHUB_WORKSPACE}/${{ inputs.input-directory }}"
         STANDALONE_EXE="${{ inputs.standalone-location }}"
 
-        NO_CAPTURE_OUTPUT_FLAG=""
         if [[ -d "${CONDA_ROOT}" ]]; then
             . "${CONDA_ROOT}/etc/profile.d/conda.sh" && conda activate
         fi
         if [[ -n "$(command -v conda)" ]]; then
             CONDA_BIN=conda
-            NO_CAPTURE_OUTPUT_FLAG='--no-capture-output'
         elif [[ -n "$(command -v mamba)" ]]; then
             CONDA_BIN=mamba
-            NO_CAPTURE_OUTPUT_FLAG='--attach  ""'
         elif [[ -n "${STANDALONE_EXE}" ]]; then
             CONDA_BIN="${STANDALONE_EXE}"
-            if [[ "$("${CONDA_BIN}" --version | cut -d' ' -f1)" == "conda" ]]; then
-                NO_CAPTURE_OUTPUT_FLAG='--no-capture-output'
-            elif [[ -n "$("${CONDA_BIN}" --help | grep mamba)" ]]; then
-                NO_CAPTURE_OUTPUT_FLAG='--attach  ""'
-            fi
         else
             echo "::error::Could not find conda or mamba binary."
             exit 1
@@ -229,10 +221,12 @@ runs:
         if [[ -n "${STANDALONE_EXE}" ]]; then
             EXTRA_CONSTRUCTOR_ARGS+=" --conda-exe ${STANDALONE_EXE}"
         fi
-        ${CONDA_BIN} run $NO_CAPTURE_OUTPUT_FLAG -p "${PREFIX}" \
-          constructor "${INPUT_DIR}"\
+        # Cannot use conda run due to https://github.com/conda/conda-standalone/issues/151
+        . "${PREFIX}/etc/profile.d/conda.sh" && conda activate
+        constructor "${INPUT_DIR}"\
             --output-dir "${ARTIFACTS_DIRECTORY}"\
             ${EXTRA_CONSTRUCTOR_ARGS}
+        conda deactivate
         # Remove the constructor-generated tmp directory
         rm -rf "${ARTIFACTS_DIRECTORY}/tmp"
         echo "::endgroup::"

--- a/action.yaml
+++ b/action.yaml
@@ -216,6 +216,7 @@ runs:
 
         echo "::group::Construct the installer"
         ARTIFACTS_DIRECTORY="${CONSTRUCTOR_WORKSPACE}/build"
+        CACHE_DIRECTORY="${CONSTRUCTOR_WORKSPACE}/constructor_cache"
         mkdir -p "${ARTIFACTS_DIRECTORY}"
         EXTRA_CONSTRUCTOR_ARGS=""
         if [[ -n "${STANDALONE_EXE}" ]]; then
@@ -225,6 +226,7 @@ runs:
         . "${PREFIX}/etc/profile.d/conda.sh" && conda activate
         constructor "${INPUT_DIR}"\
             --output-dir "${ARTIFACTS_DIRECTORY}"\
+            --cache-dir "${CACHE_DIRECTORY}"\
             ${EXTRA_CONSTRUCTOR_ARGS}
         conda deactivate
         # Remove the constructor-generated tmp directory


### PR DESCRIPTION
Using `conda run` does not work with `conda-standalone` due to https://github.com/conda/conda-standalone/issues/151. This makes the action fail if `conda-standalone` is used without a fallback `conda` installation on the runner.

To avoid this, activate the build environment directly and add tests for `conda-standalone` to catch these issues in the future.

I also noticed that the build action is not self-contained because the cache is written into `$HOME`/`%USERPROFILE%`, so I redirected it into the workspace.

Closes #68.